### PR TITLE
treat popup values as defaults and allow per player adjustments

### DIFF
--- a/src/app/common/state.ts
+++ b/src/app/common/state.ts
@@ -9,7 +9,6 @@ import {
 } from '../constants';
 import {clampValue} from '../utils/clamp-value';
 import {Browser} from './browser';
-import StorageChange = chrome.storage.StorageChange;
 
 export interface StateInterface {
   isActive: boolean;
@@ -129,31 +128,8 @@ export class State {
     await this.loadActive();
     await this.loadSpeed();
     await this.loadStep();
-    Browser.addStorageListener(this.onStorageChange.bind(this));
-  }
-
-  private onStorageChange(changes: Record<string, StorageChange>) {
-    const {isActive, speed, step} = changes;
-
-    if (typeof isActive !== 'undefined') {
-      if (isActive.newValue !== this.isActive) {
-        this.isActive = isActive.newValue;
-        this.notifyActive();
-      }
-    }
-
-    if (typeof speed !== 'undefined') {
-      if (speed.newValue !== this.speed) {
-        this.speed = speed.newValue;
-        this.notifySpeed();
-      }
-    }
-
-    if (typeof step !== 'undefined') {
-      if (step.newValue !== this.step) {
-        this.step = step.newValue;
-        this.notifyStep();
-      }
+    if (!this.isActive) {
+      this.speed = 1.0;
     }
   }
 

--- a/src/app/controllers/controls.controller.ts
+++ b/src/app/controllers/controls.controller.ts
@@ -29,17 +29,13 @@ export class ControlsController {
 
   private handleIncrease() {
     this.view.increase.addEventListener('click', async () => {
-      if (this.state.isActive) {
-        await this.state.increaseSpeed();
-      }
+      await this.state.increaseSpeed();
     });
   }
 
   private handleDecrease() {
     this.view.decrease.addEventListener('click', async () => {
-      if (this.state.isActive) {
-        await this.state.increaseSpeed(true);
-      }
+      await this.state.increaseSpeed(true);
     });
   }
 }

--- a/src/app/controllers/player.controller.ts
+++ b/src/app/controllers/player.controller.ts
@@ -29,11 +29,22 @@ export class PlayerController implements StateObserver {
 
   public onSpeedChange(speed: number): void {
     this.player.playbackRate = speed;
+    if (speed === 1.0) {
+      this.state.isActive = false;
+      this.player.preservesPitch = true;
+      this.player.mozPreservesPitch = true;
+    } else {
+      this.state.isActive = true;
+      this.player.preservesPitch = false;
+      this.player.mozPreservesPitch = false;
+    }
   }
 
   private getPlayer(): Promise<HTMLVideoElement> {
     return resolveOrRetry((resolve, retry) => {
-      const player = document.getElementsByClassName('video-stream html5-main-video')[0] as HTMLVideoElement;
+      const player = document.getElementsByClassName(
+        'video-stream html5-main-video',
+      )[0] as HTMLVideoElement;
 
       if (player && player.readyState) {
         resolve(player);

--- a/src/app/views/controls.view.ts
+++ b/src/app/views/controls.view.ts
@@ -95,24 +95,14 @@ export class ControlsView implements StateObserver {
   }
 
   private renderNode() {
-    this.node.style.display = this.state.isActive ? 'inline-flex' : 'none';
+    this.node.style.display = 'inline-flex';
   }
 
   private renderPercentage() {
-    if (this.state.isActive !== true) {
-      this.percentage.style.display = 'none';
-      return;
-    }
-
     this.percentage.textContent = `${speedToPercentage(this.state.speed, 1)} ${ControlsViewValues.percentage}`;
   }
 
   private renderSemitones() {
-    if (this.state.isActive !== true) {
-      this.semitones.textContent = ControlsViewValues.semitones;
-      return;
-    }
-
     this.semitones.textContent = `${speedToSemitones(this.state.speed, 1)} ${ControlsViewValues.semitones}`;
   }
 }

--- a/src/app/views/popup.view.ts
+++ b/src/app/views/popup.view.ts
@@ -51,18 +51,12 @@ export class PopupView implements StateObserver {
   }
 
   public renderIndicators(): void {
-    if (this.state.isActive === true) {
-      this.percentage.textContent = `${speedToPercentage(this.state.speed)} %`;
-      this.semitones.textContent = `${speedToSemitones(this.state.speed, 1)} st`;
-    } else {
-      this.percentage.textContent = 'off';
-      this.semitones.textContent = 'off';
-    }
+    this.percentage.textContent = `${speedToPercentage(this.state.speed)} %`;
+    this.semitones.textContent = `${speedToSemitones(this.state.speed, 1)} st`;
   }
 
   public renderSlider(): void {
     this.slider.value = this.state.speed.toString();
-    this.slider.disabled = !this.state.isActive;
   }
 
   private renderStep() {


### PR DESCRIPTION
right now it's not possible to separetly adjust pitch per player for example to  play music in one tab and watch something else in another

i'm not a webdev so this approach is not ideal, it would probably be the best to keep adjustment with pop up (idk how to get player per tab, are multiplayer per site common?) but it solves the issue

tested together with https://github.com/bamdadfr/screwmycode-in--extension/pull/272 